### PR TITLE
Circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,7 @@ jobs:
       - run: apt-get install -y -qq libsoprano-dev
       - run: apt-get install -y -qq qt4-default
       - run: mkdir build && cd build
+      - run: ls
+      - run: ls ..
       - run: cmake .. && make -j8
       - run: ./test/sempr_test_bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ jobs:
       - run: apt-get install -y -qq pkg-config
       - run: apt-get install -y -qq libsoprano-dev
       - run: apt-get install -y -qq qt4-default
-      - run: mkdir build && cd build
-      - run: ls
-      - run: ls ..
-      - run: cmake .. && make -j8
-      - run: ./test/sempr_test_bin
+      - run: mkdir build
+      - run: cd build && cmake .. && make -j8
+      - run: cd build && ./test/sempr_test_bin


### PR DESCRIPTION
Fixes the circleci setup.

Note: Every "- run: <cmd>" will be run in a separate sub-shell, hence "- run: cd build" alone won't do anything.