### PR TITLE
feature: pkgconfig and installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .clang_complete
 build
+doc/doxygen

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,16 @@ file(GLOB_RECURSE ODB_FILES
 # message( "found files: ${SRC_FILES}")
 # message( "found files: ${ODB_FILES}")
 
+# There are two variables to be set:
+# 1. the odb-compiler needs to know which database is used. e.g. "sqlite"
+# 2. the traits that implement serialization of new datatypes are selected based on the
+#    database, too, and need a definition of e.g. DATABASE_SQLITE.
+# So, we need to set both, and also pass our choice on to extensions of sempr.
+# - based on the "DATABASE" variable also set the definition of "DATABASE_*"
+# - add the DATABASE-variable to the pkgconfig-file. Extensions can use this to set the parameter
+#   for the odb-compiler.
+# - TODO: currently we also include -DDATABASE_* in the pkgconfig, so this is a bit redundant,
+#   isn't it?
 set(DATABASE sqlite)
 if (${DATABASE} MATCHES sqlite)
     set(CONFIG_DATABASE DATABASE_SQLITE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,12 @@ file(GLOB_RECURSE ODB_FILES
 # message( "found files: ${SRC_FILES}")
 # message( "found files: ${ODB_FILES}")
 
+set(DATABASE sqlite)
+if (${DATABASE} MATCHES sqlite)
+    set(CONFIG_DATABASE DATABASE_SQLITE)
+# elseif()
+endif()
+
 
 odb_compile(SRC_FILES
     FILES ${ODB_FILES}
@@ -35,12 +41,53 @@ odb_compile(SRC_FILES
     # PROFILE boost/uuid
     PROJECT_INCLUDE ${PROJECT_SOURCE_DIR}/include
     HEADER_PROLOGUE ${PROJECT_SOURCE_DIR}/include/sempr/storage/traits.hxx
-    DB sqlite GENERATE_QUERY GENERATE_SESSION GENERATE_SCHEMA STANDARD c++11)
+    DB ${DATABASE} GENERATE_QUERY GENERATE_SESSION GENERATE_SCHEMA STANDARD c++11)
 
 include_directories(${ODB_COMPILE_OUTPUT_DIR})
 # message("SOURCE FILES: ${SRC_FILES}")
 add_library(sempr_core SHARED ${SRC_FILES})
 target_link_libraries(sempr_core ${ODB_LIBRARIES} ${Soprano_LIBRARIES} ${GDAL_LIBRARIES})
-target_compile_definitions(sempr_core PUBLIC -DDATABASE_SQLITE)
+target_compile_definitions(sempr_core PUBLIC -D${CONFIG_DATABASE})
 # target_include_directories(sempr_core
     # PRIVATE ${ODB_COMPILE_OUTPUT_DIR} )
+
+
+## install stuff
+install(
+    TARGETS sempr_core
+    LIBRARY DESTINATION lib/sempr
+)
+# headers.
+# maybe having the "include/sempr" folder wasn't such a good idea, after all. Makes things a bit
+# weird. what shall the dir structure look like?
+# lets make it look like this:
+    # .../include/
+    # .../include/sempr/
+    # .../include/sempr/core
+    # .../include/sempr/entity
+    # .../include/sempr/...
+    # .../include/sempr-agri
+    # .../include/sempr-agri/...
+install(
+    DIRECTORY ../include/sempr
+    DESTINATION include
+)
+
+# odb-generated headers
+# well... where to put them? how to include them?
+# includes are currently used directly: #include <Point_odb.h>
+# TODO: should we change that?
+# just move them to a common folder: .../include/sempr/odb_gen
+# and add the path to the include dirs in the config file
+install(
+    DIRECTORY ${ODB_COMPILE_OUTPUT_DIR}
+    DESTINATION include/sempr
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# pkg-config-file
+configure_file("sempr-core.pc.in" "sempr-core.pc" @ONLY)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/sempr-core.pc"
+    DESTINATION lib/pkgconfig
+)

--- a/src/sempr-core.pc.in
+++ b/src/sempr-core.pc.in
@@ -1,6 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/lib/sempr
 includedir=${prefix}/include
+database=@DATABASE@
 
 Name: sempr-core
 Description: Core library of SEMPR (Semantic Environment Mapping, Processing and Reasoning)

--- a/src/sempr-core.pc.in
+++ b/src/sempr-core.pc.in
@@ -6,7 +6,7 @@ database=@DATABASE@
 Name: sempr-core
 Description: Core library of SEMPR (Semantic Environment Mapping, Processing and Reasoning)
 Version: 0.0.1
-Requires: gdal >= 2.1 libodb libodb-boost libodb-sqlite
+Requires: gdal >= 2.1 libodb libodb-boost libodb-sqlite eigen3
 Requires.private: soprano
 Libs: -L${libdir} -lsempr_core
 Cflags: -D@CONFIG_DATABASE@ -I${includedir} -I${includedir}/sempr/odb_gen

--- a/src/sempr-core.pc.in
+++ b/src/sempr-core.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib/sempr
+includedir=${prefix}/include
+
+Name: sempr-core
+Description: Core library of SEMPR (Semantic Environment Mapping, Processing and Reasoning)
+Version: 0.0.1
+Requires: gdal >= 2.1 libodb libodb-boost libodb-sqlite
+Requires.private: soprano
+Libs: -L${libdir} -lsempr_core
+Cflags: -D@CONFIG_DATABASE@ -I${includedir} -I${includedir}/sempr/odb_gen


### PR DESCRIPTION
This PR adds install instructions to the CMakeLists.txt plus a sempr-core.pc file. The latter is configured by cmake and contains the choice of database backend (sqlite, ...) as this is needed to know when compiling extensions for an already installed core.

Note: The sempr examples repository currently makes use of exactly this branch. As soon as it it merged we should also update the circleci config of the example repo.