### PR TITLE
enable modules to ask queries

### DIFF
--- a/include/sempr/processing/Module.hpp
+++ b/include/sempr/processing/Module.hpp
@@ -8,9 +8,32 @@
 #include <sempr/core/EntityEvent.hpp>
 #include <sempr/query/Query.hpp>
 
-namespace sempr { namespace processing {
+namespace sempr {
+
+namespace core {
+    class Core; // forward declaration of Core, since the module will keep a ptr to it.
+}
+
+namespace processing {
+
 
 class Module : public core::Observer{
+private:
+    /*
+        Raw pointer makes things easier in this case. It will be set by the core, and the core
+        will keep a shared_ptr to the module, so the module will die before the core. Everything
+        is fine. :)
+    */
+    core::Core* core_;
+    /* Making core a friend allows it to set the pointer without exposing yet another public method */
+    friend class core::Core;
+
+protected:
+    /**
+        Allows modules to ask queries.
+    */
+    void ask(query::Query::Ptr q);
+
 public:
     using Ptr = std::shared_ptr<Module>;
     virtual std::string type() const;

--- a/include/sempr/processing/SopranoModule.hpp
+++ b/include/sempr/processing/SopranoModule.hpp
@@ -21,7 +21,7 @@ namespace sempr { namespace processing {
         SopranoModule();
         ~SopranoModule();
 
-        std::string type() const { return "SopranoModule"; }
+        std::string type() const override { return "SopranoModule"; }
 
         /**
             add / remove triples belonging to the event to the soprano module
@@ -36,7 +36,7 @@ namespace sempr { namespace processing {
         /**
             answer a SPARQLQuery
         */
-        void answer(query::SPARQLQuery::Ptr query);
+        void answerSPARQL(query::SPARQLQuery::Ptr query);
 
     private:
         /// all updates take place inside the base model

--- a/src/core/Core.cpp
+++ b/src/core/Core.cpp
@@ -48,6 +48,9 @@ void Core::removeEntity(entity::Entity::Ptr entity) {
 
 void Core::addModule(processing::Module::Ptr module) {
     modules_.push_back(module);
+    module->core_ = this;   // allow the module to ask queries later on.
+    // NOTE: If we ever implement a "removeModule" make sure to un-set the pointer.
+
     eventBroker_->addObserver(module);
 }
 

--- a/src/processing/Module.cpp
+++ b/src/processing/Module.cpp
@@ -1,4 +1,5 @@
 #include <sempr/processing/Module.hpp>
+#include <sempr/core/Core.hpp>
 
 namespace sempr { namespace processing {
 
@@ -9,6 +10,11 @@ std::string Module::type() const {
 void Module::answer(query::Query::Ptr q)
 {
     notify(q);
+}
+
+void Module::ask(query::Query::Ptr q)
+{
+    if (this->core_) { this->core_->answerQuery(q); }
 }
 
 

--- a/src/processing/SopranoModule.cpp
+++ b/src/processing/SopranoModule.cpp
@@ -27,7 +27,7 @@ SopranoModule::SopranoModule()
     // for answering sparql queries
     addOverload<query::SPARQLQuery>(
         [this](query::SPARQLQuery::Ptr q) {
-            this->answer(q);
+            this->answerSPARQL(q);
         }
     );
 }
@@ -106,7 +106,7 @@ void SopranoModule::process(core::EntityEvent<entity::RuleSet>::Ptr event)
 
 
 
-void SopranoModule::answer(query::SPARQLQuery::Ptr query)
+void SopranoModule::answerSPARQL(query::SPARQLQuery::Ptr query)
 {
     if (dirty_) {
         infmodel_->performInference();


### PR DESCRIPTION
As simple as these changes seem, as powerful they are.

This PR extends processing modules with a protected method `Module::ask(Query::Ptr)`: Modules can use this method to ask queries and thus become more powerful in combination than they could ever be alone. :)

I'm not sure if the raw pointer and a friend declaration in Module is the cleanest way to do this, but it is a very small change, was fast to do, and works. In the future we will need to implement a concrete strategy within the Core to handle queries, a module-hierarchy or something similar, or **at least** extend the query with information about its sender, so a module will never need to answer a query that itself asked.