### PR TITLE
create pch of all sempr-core includes

### DIFF
--- a/cmake/PCH.cmake
+++ b/cmake/PCH.cmake
@@ -33,7 +33,7 @@ function(add_precompiled_header _output _input _flags)
     set(_CLANG_CXX_FLAGS "")
     foreach(_flag ${_flags_list})
         if(_flag MATCHES "-fopenmp")
-            # ... just skip it.
+            # ... just skip it. no need for openmp if we just want a precompiled header for code completion
             #list(APPEND _CLANG_CXX_FLAGS "-fopenmp=libomp" "-fopenmp")
         else()
             list(APPEND _CLANG_CXX_FLAGS ${_flag})
@@ -46,9 +46,14 @@ function(add_precompiled_header _output _input _flags)
     ## At build time
     ##
     # compile the all_include.cpp to generate a precompiled header
+    find_program(_CLANG_EXE clang++)
+    if (NOT _CLANG_EXE)
+        message(FATAL_ERROR "Requested precompiled header \"${_output}\", but clang++ couldn't be found.")
+    endif()
+
     add_custom_command(
         OUTPUT ${_output}
-        COMMAND clang++
+        COMMAND ${_CLANG_EXE}
         ARGS -xc++-header -Xclang ${_CLANG_CXX_FLAGS} -Wno-everything ${_flags} -o ${_output} ${${_output}_iflags} ${_tmpfile}
         DEPENDS ${${_input}}
         COMMENT "Building precompiled header ${_output}"

--- a/cmake/PCH.cmake
+++ b/cmake/PCH.cmake
@@ -1,0 +1,62 @@
+# -----------------------------------------------
+# Creates precompiled header files using clang.
+# Can be used to speed up autocompletion:
+# Create the precompiled header:
+#   set(header a.hpp b.hpp ...)
+#   add_precompiled_header(somename.pch header ${additional_flags})
+# then, include it in other projects:
+# .clang_complete
+#   -include-pch somename.pch
+# -----------------------------------------------
+function(add_precompiled_header _output _input _flags)
+    ##
+    ## At cmake-generation-time
+    ##
+    # create a new c-file that includes everything.
+    set(_compilestr "")
+    foreach(_incl ${${_input}})
+        set(_compilestr "${_compilestr}\n#include \"${_incl}\"")
+    endforeach()
+    set(_tmpfile ${CMAKE_CURRENT_BINARY_DIR}/${_output}_all_include.cpp)
+    file(WRITE ${_tmpfile} ${_compilestr})
+
+
+    ## get a list of the current include directories, and parse them to "-I/path/"
+    get_property(${_output}_includedirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+    set(${_output}_iflags "")
+    foreach(_dir ${${_output}_includedirs})
+        list(APPEND ${_output}_iflags "-I${_dir}")
+    endforeach()
+
+    ## process CXX_FLAGS: -fopenmp in gcc must be -fopenmp=libomp in clang, if enabled at all..
+    string(REPLACE " " ";" _flags_list "${CMAKE_CXX_FLAGS}")
+    set(_CLANG_CXX_FLAGS "")
+    foreach(_flag ${_flags_list})
+        if(_flag MATCHES "-fopenmp")
+            # ... just skip it.
+            #list(APPEND _CLANG_CXX_FLAGS "-fopenmp=libomp" "-fopenmp")
+        else()
+            list(APPEND _CLANG_CXX_FLAGS ${_flag})
+        endif()
+    endforeach()
+    message("CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
+    message("_CLANG_CXX_FLAGS ${_CLANG_CXX_FLAGS}")
+
+    ##
+    ## At build time
+    ##
+    # compile the all_include.cpp to generate a precompiled header
+    add_custom_command(
+        OUTPUT ${_output}
+        COMMAND clang++
+        ARGS -xc++-header -Xclang ${_CLANG_CXX_FLAGS} -Wno-everything ${_flags} -o ${_output} ${${_output}_iflags} ${_tmpfile}
+        DEPENDS ${${_input}}
+        COMMENT "Building precompiled header ${_output}"
+    )
+
+    ## add the custom target to actually do build the pch
+    add_custom_target(${_output}_pch_target ALL DEPENDS ${_output})
+endfunction()
+
+
+# add_precompiled_header(myprecompiledheader.pch ${CMAKE_CURRENT_LIST_DIR}/src/someinclude.hpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,29 @@ target_compile_definitions(sempr_core PUBLIC -D${CONFIG_DATABASE})
     # PRIVATE ${ODB_COMPILE_OUTPUT_DIR} )
 
 
+
+
+
+##
+## generate precompiled header (for autocomplete-clang)
+##
+# check if clang exists
+find_program(CLANG NAMES clang++)
+if (NOT CLANG)
+    message("clang not found, not generating pch.")
+else()
+    message("FOUND CLANG: ${CLANG}")
+    file(GLOB_RECURSE ALL_HEADERS ../include/*)
+    include(${PROJECT_SOURCE_DIR}/cmake/PCH.cmake)
+    add_precompiled_header(sempr-core.pch ALL_HEADERS "-D${CONFIG_DATABASE}")
+
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/sempr-core.pch
+        DESTINATION include/sempr
+    )
+endif()
+
+
 ## install stuff
 install(
     TARGETS sempr_core

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,13 +68,23 @@ target_compile_definitions(sempr_core PUBLIC -D${CONFIG_DATABASE})
 ##
 ## generate precompiled header (for autocomplete-clang)
 ##
+# Define a list of headers to exclude from the pch. Use this while working on SEMPR to avoid
+# having to generate from scratch when adding a new function etc.
+file(GLOB_RECURSE EXCLUDE_FROM_PCH
+    #../include/sempr/processing/SopranoModule.hpp # e.g.
+)
+
 # check if clang exists
-find_program(CLANG NAMES clang++)
+find_program(CLANG clang++)
 if (NOT CLANG)
     message("clang not found, not generating pch.")
 else()
     message("FOUND CLANG: ${CLANG}")
     file(GLOB_RECURSE ALL_HEADERS ../include/*)
+    if (EXCLUDE_FROM_PCH)
+        list(REMOVE_ITEM ALL_HEADERS ${EXCLUDE_FROM_PCH})
+    endif()
+
     include(${PROJECT_SOURCE_DIR}/cmake/PCH.cmake)
     add_precompiled_header(sempr-core.pch ALL_HEADERS "-D${CONFIG_DATABASE}")
 


### PR DESCRIPTION
This PR adds some... CMake-Magic. :)

It's not real feature of SEMPR. It just helps me not losing my mind about horribly slow autocompletion: To speed things up, the compilation process of SEMPR saves a precompiled version of the headers and installs it into `include/sempr/sempr-core.pch`.

To use it with `autocomplete-clang`, modify your `.clang_complete`:
```
-include-pch
/path/to/sempr/installation/include/sempr/sempr-core.pch
```
Yes, the newline is necessary. It's a bug in clang.

The result? Instead of waiting like 5 seconds for every autocompletion, everything happens almost instantaneously. :)

**Notice:** This is mainly meant to be used in other projects, not when working on sempr-core. If you do, keep in mind that your autocompletion might be incomplete due to old pch-files. **Also**, the installation is a bit fake: The pch-file currently still references a cmake-generated `sempr-core.pch_all_includes.cpp`-file located in the sempr-core-build-directory. To make this independent I'll need to change the cmake to create the pch out of the installed files. But hey, it works for me.
**Oh, one more thing:** The autocomple-clang-option "keep system header documentation" needs to be turned **off**. I'm missing some compilation-parameter there, I guess....