### PR TITLE
feature: spatial index

### DIFF
--- a/include/sempr/processing/SpatialIndex.hpp
+++ b/include/sempr/processing/SpatialIndex.hpp
@@ -1,0 +1,84 @@
+#ifndef SEMPR_PROCESSING_SPATIALINDEX_HPP_
+#define SEMPR_PROCESSING_SPATIALINDEX_HPP_
+
+#include <sempr/processing/Module.hpp>
+#include <sempr/entity/spatial/Geometry.hpp>
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/box.hpp>
+#include <boost/geometry/index/rtree.hpp>
+
+#include <vector>
+#include <map>
+
+namespace sempr { namespace processing {
+
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+
+
+/**
+    This class implements a spatial index for geometry-entities. It listens to events of Geometry
+    and SpatialReference and answers SpatialQueries, which allows us to ask for geometries which
+    do (not) intersect / contain / are within a given axis aligned bounding box referenced to the
+    root frame.
+    TODO: Regarding the root-frame: Currently the SpatialIndex assumes that everything is located in
+    a common root-frame and does neither account for separate chains of LocalCS nor for ProjectionCS
+    and GeographicCS being linked by an implicit "earth". We should extend the SpatialIndex *and*
+    the SpatialQuery to be able to specifiy which frame we are interested in, and the index should
+    only contain geometries which are located relative to the given frame (or a child-frame of it).
+    The bridge between ProjectionCS and GeographicCS could be a bit more difficult as we will need
+    coordinate transformations done by GDAL in the process.
+*/
+class SpatialIndex : public Module {
+public:
+    using Ptr = std::shared_ptr<SpatialIndex>;
+    std::string type() const override;
+
+    SpatialIndex();
+
+    /// just for me to remember how querying works.
+    void test();
+
+private:
+    /**
+        Specify what is stored in the R-Tree:
+            boxes, made out of points, consisting of 3 floats, in cartesian space.
+        NOTE: Boost seems to support geographic and spherical coordinates (lat-long etc) here, how
+        does this affect the RTree? Can we use this to support indexing on lat-lon later on?
+    */
+    typedef bg::model::point<float, 3, bg::cs::cartesian> bPoint;
+    typedef bg::model::box<bPoint> bBox;
+    typedef std::pair<bBox, entity::Geometry::Ptr> bValue;
+
+    /**
+        The actual R-Tree.
+    */
+    bgi::rtree<bValue, bgi::quadratic<16> > rtree_;
+
+    /**
+        A mapping of Geometry-->bValue for easier updates of the RTree
+    */
+    std::map<entity::Geometry::Ptr, bValue> geo2box_;
+
+    /**
+        Process changes of geometries: New are inserted into the RTree, changed are recomputed
+    */
+    void process(core::EntityEvent<entity::Geometry>::Ptr geoEvent);
+    void process(core::EntityEvent<entity::SpatialReference>::Ptr refEvent);
+    void processChangedCS(entity::SpatialReference::Ptr cs);
+
+    // the actual processing:
+    void insertGeo(entity::Geometry::Ptr geo);
+    void updateGeo(entity::Geometry::Ptr geo);
+    void removeGeo(entity::Geometry::Ptr geo);
+
+    /** Create a pair of bounding-box and ptr */
+    bValue createEntry(entity::Geometry::Ptr geo);
+};
+
+
+}}
+
+#endif /* end of include guard SEMPR_PROCESSING_SPATIALINDEX_HPP_ */

--- a/include/sempr/processing/SpatialIndex.hpp
+++ b/include/sempr/processing/SpatialIndex.hpp
@@ -9,6 +9,8 @@
 #include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/index/rtree.hpp>
 
+#include <sempr/query/SpatialIndexQuery.hpp>
+
 #include <vector>
 #include <map>
 
@@ -38,10 +40,11 @@ public:
 
     SpatialIndex();
 
-    /// just for me to remember how querying works.
-    void test();
+    /**
+        Answer a SpatialIndexQuery
+    */
+    void lookup(query::SpatialIndexQuery::Ptr query) const;
 
-private:
     /**
         Specify what is stored in the R-Tree:
             boxes, made out of points, consisting of 3 floats, in cartesian space.
@@ -51,11 +54,13 @@ private:
     typedef bg::model::point<float, 3, bg::cs::cartesian> bPoint;
     typedef bg::model::box<bPoint> bBox;
     typedef std::pair<bBox, entity::Geometry::Ptr> bValue;
+    typedef bgi::rtree<bValue, bgi::quadratic<16> > RTree;
 
+private:
     /**
         The actual R-Tree.
     */
-    bgi::rtree<bValue, bgi::quadratic<16> > rtree_;
+    RTree rtree_;
 
     /**
         A mapping of Geometry-->bValue for easier updates of the RTree

--- a/include/sempr/query/SpatialIndexQuery.hpp
+++ b/include/sempr/query/SpatialIndexQuery.hpp
@@ -1,0 +1,92 @@
+#ifndef SEMPR_QUERY_SPATIALQUERY_HPP_
+#define SEMPR_QUERY_SPATIALQUERY_HPP_
+
+#include <sempr/query/Query.hpp>
+#include <sempr/entity/spatial/Geometry.hpp>
+#include <vector>
+#include <Eigen/Geometry>
+#include <set>
+
+namespace sempr { namespace query {
+
+
+/**
+    This class defines queries to the SpatialIndex, which can be from a subset of the boost
+    spatial predicates. A query consists of a few different things:
+        1. [x] a geometry which defines the region of interest
+        2. [x] (obviously?) a coordinate system in which the above mentioned geometry lives
+        3. [x] a spatial predicate, something like "within", "intersects", etc.
+        4. [x] a set of results.
+        (5. [ ] the template parameter can be used to select which type of geometries will be returned)
+
+    It only provides an interface to the SpatialIndex but does not provide any further functionality
+    beyond the comparison of bounding boxes. Any work/checks on concrete geometries must be done
+    by the user or a specialized processing module.
+*/
+class SpatialIndexQuery : public Query {
+public:
+    using Ptr = std::shared_ptr<SpatialIndexQuery>;
+    ~SpatialIndexQuery();
+
+    std::string type() const override { return "SpatialIndexQuery"; }
+
+    /** The set of geometries matching the criterium */
+    std::set<entity::Geometry::Ptr> results;
+
+    enum QueryType {
+        WITHIN = 0, NOT_WITHIN,
+        CONTAINS, NOT_CONTAINS,
+        INTERSECTS, NOT_INTERSECTS
+    };
+
+    /** returns the mode of the query: WITHIN, NOT_WITHIN, ... */
+    QueryType mode() const;
+    /** set the mode of the query */
+    void mode(QueryType m);
+
+    /** get hold of the reference geometry (the 8 cornerpoints of the bounding box) */
+    entity::Geometry::Ptr refGeo();
+
+    /**
+        Query for everything within the bounding box of 'geometry'. Passes the Envelope3D of
+        the geometry to 'withinBox'.
+    */
+    static SpatialIndexQuery::Ptr withinBoxOf(entity::Geometry::Ptr geometry);
+
+    /**
+        Query for everything within the bbox specified. Explicit coordinate system.
+        This creates a new GeometryCollection that is used for the query.
+     */
+    static SpatialIndexQuery::Ptr withinBox(const Eigen::Vector3d& lower, const Eigen::Vector3d& upper,
+                                            entity::SpatialReference::Ptr cs);
+
+    /**
+        TODO: how to say "not within?"
+        This would be nice:
+            SpatialIndexQuery::Ptr q = !SpatialIndexQuery::within(geo);
+        But we also want to get a SpatialIndexQuery::Ptr, for which an overloaded operator!() could
+        break stuff. Implementing it only for SpatialIndexQuery (w/o Ptr) would lead to...
+            SpatialIndexQuery::Ptr q = !(*SpatialIndexQuery::within(geo));
+        So what about:
+            SpatialIndexQuery::Ptr q = SpatialIndexQuery::within(geo);
+            q->invert();
+    */
+
+
+    // TODO CONTAINS and INTERSECTS
+private:
+    // helper: construct collection of bbox-corner-points from a geometry
+
+    // use static methods to construct queries
+    SpatialIndexQuery();
+
+    // the actual type
+    QueryType qtype_;
+
+    // the reference geometry
+    entity::Geometry::Ptr refGeo_;
+};
+
+}}
+
+#endif /* end of include guard SEMPR_QUERY_SPATIALQUERY_HPP_ */

--- a/include/sempr/query/SpatialIndexQuery.hpp
+++ b/include/sempr/query/SpatialIndexQuery.hpp
@@ -46,10 +46,13 @@ public:
         INTERSECTS, NOTINTERSECTS
     };
 
+
     /** returns the mode of the query: WITHIN, NOT_WITHIN, ... */
     QueryType mode() const;
     /** set the mode of the query */
     void mode(QueryType m);
+    /** inverts the mode: WITHIN <-> NOTWITHIN etc. */
+    void invert();
 
     /** get hold of the reference geometry (the 8 cornerpoints of the bounding box) */
     entity::Geometry::Ptr refGeo();
@@ -59,14 +62,23 @@ public:
         the geometry to 'withinBox'.
     */
     static SpatialIndexQuery::Ptr withinBoxOf(entity::Geometry::Ptr geometry);
+    static SpatialIndexQuery::Ptr containsBoxOf(entity::Geometry::Ptr geometry);
+    static SpatialIndexQuery::Ptr intersectsBoxOf(entity::Geometry::Ptr geometry);
+
 
     /**
         Query for everything within the bbox specified. Explicit coordinate system.
         This creates a new GeometryCollection that is used for the query.
      */
-    static SpatialIndexQuery::Ptr withinBox(const Eigen::Vector3d& lower, const Eigen::Vector3d& upper,
+    static SpatialIndexQuery::Ptr withinBox(const Eigen::Vector3d& lower,
+                                            const Eigen::Vector3d& upper,
                                             entity::SpatialReference::Ptr cs);
-
+    static SpatialIndexQuery::Ptr containsBox(  const Eigen::Vector3d& lower,
+                                                const Eigen::Vector3d& upper,
+                                                entity::SpatialReference::Ptr cs);
+    static SpatialIndexQuery::Ptr intersectsBox(const Eigen::Vector3d& lower,
+                                                const Eigen::Vector3d& upper,
+                                                entity::SpatialReference::Ptr cs);
     /**
         TODO: how to say "not within?"
         This would be nice:
@@ -83,6 +95,14 @@ public:
     // TODO CONTAINS and INTERSECTS
 private:
     // helper: construct collection of bbox-corner-points from a geometry
+    void setupRefGeo(const Eigen::Vector3d& lower, const Eigen::Vector3d& upper,
+                entity::SpatialReference::Ptr cs);
+
+    // helper: create query from geo or upper/lower and a type
+    static SpatialIndexQuery::Ptr createQuery(entity::Geometry::Ptr geo, QueryType type);
+    static SpatialIndexQuery::Ptr createQuery(const Eigen::Vector3d& lower, const Eigen::Vector3d& upper,
+                                        entity::SpatialReference::Ptr cs, QueryType type);
+
 
     // use static methods to construct queries
     SpatialIndexQuery();

--- a/include/sempr/query/SpatialIndexQuery.hpp
+++ b/include/sempr/query/SpatialIndexQuery.hpp
@@ -33,10 +33,17 @@ public:
     /** The set of geometries matching the criterium */
     std::set<entity::Geometry::Ptr> results;
 
+    /*
+        NOTE:   I'd prefer "NOT_WITHIN" etc instead of "NOTWITHIN", but sadly newer versions of
+                libsqlite3-dev (3.11) have a
+                    #define NOT_WITHIN 0
+                inside of sqlite3.h, which makes the preprocessor expand it here, and the compiler
+                throwing an error pointing at NOT_WITHIN...
+    */
     enum QueryType {
-        WITHIN = 0, NOT_WITHIN,
-        CONTAINS, NOT_CONTAINS,
-        INTERSECTS, NOT_INTERSECTS
+        WITHIN = 0, NOTWITHIN,
+        CONTAINS, NOTCONTAINS,
+        INTERSECTS, NOTINTERSECTS
     };
 
     /** returns the mode of the query: WITHIN, NOT_WITHIN, ... */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,8 +71,10 @@ target_compile_definitions(sempr_core PUBLIC -D${CONFIG_DATABASE})
 # Define a list of headers to exclude from the pch. Use this while working on SEMPR to avoid
 # having to generate from scratch when adding a new function etc.
 file(GLOB_RECURSE EXCLUDE_FROM_PCH
-    #../include/sempr/processing/SopranoModule.hpp # e.g.
+    ../include/sempr/processing/SpatialIndex.hpp
+    ../include/sempr/query/SpatialQuery.hpp
 )
+
 
 # check if clang exists
 find_program(CLANG clang++)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,8 +71,8 @@ target_compile_definitions(sempr_core PUBLIC -D${CONFIG_DATABASE})
 # Define a list of headers to exclude from the pch. Use this while working on SEMPR to avoid
 # having to generate from scratch when adding a new function etc.
 file(GLOB_RECURSE EXCLUDE_FROM_PCH
-    ../include/sempr/processing/SpatialIndex.hpp
-    ../include/sempr/query/SpatialQuery.hpp
+    # ../include/sempr/processing/SpatialIndex.hpp
+    # ../include/sempr/query/SpatialIndexQuery.hpp
 )
 
 

--- a/src/entity/spatial/SpatialObject.cpp
+++ b/src/entity/spatial/SpatialObject.cpp
@@ -8,6 +8,8 @@ namespace sempr { namespace entity {
 SpatialObject::SpatialObject()
     : Entity(new core::IDGen<SpatialObject>())
 {
+    this->setDiscriminator<SpatialObject>();
+    
     geometry_.reset(new GeometryCollection());
     property_.reset(new RDFPropertyMap(*this));
 

--- a/src/processing/SpatialIndex.cpp
+++ b/src/processing/SpatialIndex.cpp
@@ -1,0 +1,184 @@
+#include <sempr/processing/SpatialIndex.hpp>
+#include <sempr/core/EntityEvent.hpp>
+#include <sempr/entity/spatial/LocalTransformation.hpp>
+
+#include <gdal/ogr_core.h>
+
+namespace sempr { namespace processing {
+
+SpatialIndex::SpatialIndex()
+{
+    // listen to geometries
+    this->addOverload<core::EntityEvent<entity::Geometry> >(
+        [this](core::EntityEvent<entity::Geometry>::Ptr event) {
+            this->process(event);
+        }
+    );
+
+    // listen to spatial references
+    this->addOverload<core::EntityEvent<entity::SpatialReference> >(
+        [this](core::EntityEvent<entity::SpatialReference>::Ptr event) {
+            this->process(event);
+        }
+    );
+}
+
+std::string SpatialIndex::type() const
+{
+    return "SpatialIndex";
+}
+
+void SpatialIndex::test()
+{
+    std::vector<bValue> results;
+    bBox region(
+        bPoint(0, 0, 0),
+        bPoint(5, 5, 5)
+    );
+    auto predicate = bgi::intersects(region);
+    // auto predicate = bgi::contains(region);
+    // auto predicate = bgi::within(region);
+    // auto predicate = !bgi::within(region);
+    rtree_.query( predicate, std::back_inserter(results));
+    for (auto r : results)
+    {
+        std::cout << "predicate matched: " << r.second->id() << std::endl;
+    }
+}
+
+void SpatialIndex::process(core::EntityEvent<entity::Geometry>::Ptr geoEvent)
+{
+    typedef core::EntityEvent<entity::Geometry>::EventType EType;
+    entity::Geometry::Ptr geo = geoEvent->getEntity();
+
+    switch (geoEvent->what()) {
+        case EType::CREATED:
+        case EType::LOADED:
+            insertGeo(geo);
+            break;
+        case EType::CHANGED:
+            updateGeo(geo);
+            break;
+        case EType::REMOVED:
+            removeGeo(geo);
+            break;
+    }
+}
+
+void SpatialIndex::process(core::EntityEvent<entity::SpatialReference>::Ptr refEvent)
+{
+    typedef core::EntityEvent<entity::SpatialReference>::EventType EType;
+    switch (refEvent->what()) {
+        case EType::CREATED:
+        case EType::LOADED:
+            // nothing to do.
+            break;
+        case EType::CHANGED:
+            // check which geometries are affected and update them.
+            processChangedCS(refEvent->getEntity());
+            break;
+        case EType::REMOVED:
+            // well...
+            // what happens if we remove a SpatialReference that some geometry is pointing to?
+            // (why would be do that? how can we prevent that?)
+            break;
+    }
+}
+
+
+void SpatialIndex::processChangedCS(entity::SpatialReference::Ptr cs)
+{
+    // we need to check every geometry currently in the index, if it is affected.
+    for (auto entry : geo2box_)
+    {
+        if (entry.first->getCS()->isChildOf(cs))
+        {
+            // well, in that case update it.
+            updateGeo(entry.first);
+        }
+    }
+}
+
+
+SpatialIndex::bValue SpatialIndex::createEntry(entity::Geometry::Ptr geo)
+{
+    // get the 3d envelope of the geometry.
+    OGREnvelope3D envelope;
+    geo->geometry()->getEnvelope(&envelope);
+    // this envelope is in the coordinate system of the geometry. But what we need is an envelope
+    // that is axis aligned with the root reference system. We could transform the geometry to root,
+    // take the envelope and transform it back, but that is just ridiculus. Instead: Create a
+    // bounding-box-geometry (8 points, one for each corner), transform it, and take its envelope.
+    // ---
+    // create a geometry with the matching extends: 8 point, every corner must be checked!
+    OGRMultiPoint mp;
+    OGRPoint* p;
+    p = new OGRPoint(envelope.MinX, envelope.MinY, envelope.MinZ); mp.addGeometryDirectly(p);
+    p = new OGRPoint(envelope.MinX, envelope.MinY, envelope.MaxZ); mp.addGeometryDirectly(p);
+    p = new OGRPoint(envelope.MinX, envelope.MaxY, envelope.MinZ); mp.addGeometryDirectly(p);
+    p = new OGRPoint(envelope.MinX, envelope.MaxY, envelope.MaxZ); mp.addGeometryDirectly(p);
+    p = new OGRPoint(envelope.MaxX, envelope.MinY, envelope.MinZ); mp.addGeometryDirectly(p);
+    p = new OGRPoint(envelope.MaxX, envelope.MinY, envelope.MaxZ); mp.addGeometryDirectly(p);
+    p = new OGRPoint(envelope.MaxX, envelope.MaxY, envelope.MinZ); mp.addGeometryDirectly(p);
+    p = new OGRPoint(envelope.MaxX, envelope.MaxY, envelope.MaxZ); mp.addGeometryDirectly(p);
+
+    // transform the geometry
+    LocalTransformation tf(geo->getCS()->transformationToRoot());
+    mp.transform(&tf);
+
+    // get the new envelope
+    mp.getEnvelope(&envelope);
+    // mp will run out of scope and destroy the points with it.
+
+    // create the bBox out of bPoints.
+    bBox box(
+        bPoint(envelope.MinX, envelope.MinY, envelope.MinZ),
+        bPoint(envelope.MaxX, envelope.MaxY, envelope.MaxZ)
+    );
+
+    return bValue(box, geo);
+}
+
+
+void SpatialIndex::insertGeo(entity::Geometry::Ptr geo)
+{
+    // sanity: it needs a geometry, and a spatial reference.
+    if (!geo->geometry() || !geo->getCS()) return;
+
+    // create a new entry
+    bValue entry = createEntry(geo);
+    // save it in our map
+    geo2box_[geo] = entry;
+    // and insert it into the RTree
+    rtree_.insert(entry);
+
+
+    std::cout << "inserted " << geo->id() << " into spatial index" << '\n';
+}
+
+void SpatialIndex::updateGeo(entity::Geometry::Ptr geo)
+{
+    // update? lets remove the old one first.
+    removeGeo(geo);
+
+    // sanity: it needs a geometry, and a spatial reference.
+    if (!geo->geometry() || !geo->getCS()) return
+
+    // and re-insert it with updated data.
+    insertGeo(geo);
+}
+
+void SpatialIndex::removeGeo(entity::Geometry::Ptr geo)
+{
+    // find the map-entry
+    auto it = geo2box_.find(geo);
+    if (it != geo2box_.end())
+    {
+        // remove from rtree
+        rtree_.remove(it->second);
+        // and from the map
+        geo2box_.erase(it);
+    }
+}
+
+}}

--- a/src/processing/SpatialIndex.cpp
+++ b/src/processing/SpatialIndex.cpp
@@ -3,7 +3,7 @@
 #include <sempr/entity/spatial/LocalTransformation.hpp>
 #include <iterator>
 
-#include <gdal/ogr_core.h>
+#include <ogr_core.h>
 
 namespace sempr { namespace processing {
 

--- a/src/processing/SpatialIndex.cpp
+++ b/src/processing/SpatialIndex.cpp
@@ -197,7 +197,13 @@ void SpatialIndex::insertGeo(entity::Geometry::Ptr geo)
     rtree_.insert(entry);
 
 
-    // std::cout << "inserted " << geo->id() << " into spatial index. " << '\n';
+    std::cout << "inserted " << geo->id() << " into spatial index. AABB: "
+        << "(" << entry.first.min_corner().get<0>() << ", " <<
+                  entry.first.min_corner().get<1>() << ", " <<
+                  entry.first.min_corner().get<2>() << ")  --  (" <<
+                  entry.first.max_corner().get<0>() << ", " <<
+                  entry.first.max_corner().get<1>() << ", " <<
+                  entry.first.max_corner().get<2>() << ")" << '\n';
 }
 
 void SpatialIndex::updateGeo(entity::Geometry::Ptr geo)
@@ -206,7 +212,7 @@ void SpatialIndex::updateGeo(entity::Geometry::Ptr geo)
     removeGeo(geo);
 
     // sanity: it needs a geometry, and a spatial reference.
-    if (!geo->geometry() || !geo->getCS()) return
+    if (!geo->geometry() || !geo->getCS()) return;
 
     // and re-insert it with updated data.
     insertGeo(geo);

--- a/src/processing/SpatialIndex.cpp
+++ b/src/processing/SpatialIndex.cpp
@@ -197,7 +197,7 @@ void SpatialIndex::insertGeo(entity::Geometry::Ptr geo)
     rtree_.insert(entry);
 
 
-    std::cout << "inserted " << geo->id() << " into spatial index" << '\n';
+    // std::cout << "inserted " << geo->id() << " into spatial index. " << '\n';
 }
 
 void SpatialIndex::updateGeo(entity::Geometry::Ptr geo)

--- a/src/processing/SpatialIndex.cpp
+++ b/src/processing/SpatialIndex.cpp
@@ -60,7 +60,25 @@ void SpatialIndex::lookup(query::SpatialIndexQuery::Ptr query) const
         case QueryType::WITHIN:
             rtree_.query(bgi::within(region), std::back_inserter(tmpResults));
             break;
-
+        case QueryType::NOTWITHIN:
+            rtree_.query(!bgi::within(region), std::back_inserter(tmpResults));
+            break;
+        /*
+        // TODO: contains is introduced in boost 1.55, but ros indigo needs 1.54.
+        // maybe its time for me to upgrade to 16.04 and kinetic...
+        case QueryType::CONTAINS:
+            rtree_.query(bgi::contains(region), std::back_inserter(tmpResults));
+            break;
+        case QueryType::NOTCONTAINS:
+            rtree_.query(!bgi::contains(region), std::back_inserter(tmpResults));
+            break;
+        */
+        case QueryType::INTERSECTS:
+            rtree_.query(bgi::intersects(region), std::back_inserter(tmpResults));
+            break;
+        case QueryType::NOTINTERSECTS:
+            rtree_.query(!bgi::intersects(region), std::back_inserter(tmpResults));
+            break;
         default:
             std::cout << "SpatialIndex: Mode " << query->mode() << " not implemented." << '\n';
     }

--- a/src/query/SpatialIndexQuery.cpp
+++ b/src/query/SpatialIndexQuery.cpp
@@ -1,0 +1,73 @@
+#include <sempr/query/SpatialIndexQuery.hpp>
+#include <sempr/entity/spatial/GeometryCollection.hpp>
+
+namespace sempr { namespace query {
+
+SpatialIndexQuery::SpatialIndexQuery()
+{
+}
+
+SpatialIndexQuery::~SpatialIndexQuery()
+{
+}
+
+SpatialIndexQuery::QueryType SpatialIndexQuery::mode() const
+{
+    return qtype_;
+}
+
+void SpatialIndexQuery::mode(SpatialIndexQuery::QueryType m)
+{
+    qtype_ = m;
+}
+
+entity::Geometry::Ptr SpatialIndexQuery::refGeo()
+{
+    return refGeo_;
+}
+
+SpatialIndexQuery::Ptr SpatialIndexQuery::withinBox( const Eigen::Vector3d& lower,
+                                        const Eigen::Vector3d& upper,
+                                        entity::SpatialReference::Ptr cs)
+{
+    if (!cs) return SpatialIndexQuery::Ptr();
+
+    /* -- this could/should be a helper function -- */
+    entity::GeometryCollection::Ptr corners(new entity::GeometryCollection());
+    corners->setCS(cs);
+
+    OGRPoint* p;
+    p = new OGRPoint(lower.x(), lower.y(), lower.z()); corners->geometry()->addGeometryDirectly(p);
+    p = new OGRPoint(lower.x(), lower.y(), upper.z()); corners->geometry()->addGeometryDirectly(p);
+    p = new OGRPoint(lower.x(), upper.y(), lower.z()); corners->geometry()->addGeometryDirectly(p);
+    p = new OGRPoint(lower.x(), upper.y(), upper.z()); corners->geometry()->addGeometryDirectly(p);
+    p = new OGRPoint(upper.x(), lower.y(), lower.z()); corners->geometry()->addGeometryDirectly(p);
+    p = new OGRPoint(upper.x(), lower.y(), upper.z()); corners->geometry()->addGeometryDirectly(p);
+    p = new OGRPoint(upper.x(), upper.y(), lower.z()); corners->geometry()->addGeometryDirectly(p);
+    p = new OGRPoint(upper.x(), upper.y(), upper.z()); corners->geometry()->addGeometryDirectly(p);
+    /* -- ---- -- */
+
+    SpatialIndexQuery::Ptr query(new SpatialIndexQuery());
+    query->mode(SpatialIndexQuery::WITHIN);
+    query->refGeo_ = corners;
+
+    return query;
+}
+
+
+SpatialIndexQuery::Ptr SpatialIndexQuery::withinBoxOf(entity::Geometry::Ptr geometry)
+{
+    OGREnvelope3D env;
+    geometry->geometry()->getEnvelope(&env);
+    Eigen::Vector3d lower, upper;
+    lower.x() = env.MinX;
+    lower.y() = env.MinY;
+    lower.z() = env.MinZ;
+    upper.x() = env.MaxX;
+    upper.y() = env.MaxY;
+    upper.z() = env.MaxZ;
+
+    return SpatialIndexQuery::withinBox(lower, upper, geometry->getCS());
+}
+
+}}

--- a/test/SEMPR_tests.cpp
+++ b/test/SEMPR_tests.cpp
@@ -35,6 +35,7 @@
 #include <sempr/entity/spatial/ProjectionCS.hpp>
 
 #include <sempr/processing/SopranoModule.hpp>
+#include <sempr/processing/SpatialIndex.hpp>
 
 using namespace sempr::core;
 using namespace sempr::storage;
@@ -958,4 +959,107 @@ BOOST_AUTO_TEST_SUITE(reference_systems)
         BOOST_CHECK_CLOSE(p->geometry()->getY(), -100, 0.0000001);
     }
 
+BOOST_AUTO_TEST_SUITE_END()
+
+
+
+
+void setupQuadrangle(OGRPolygon* poly, const std::array<float, 3>& min, const std::array<float, 3>& max)
+{
+    // OGRLineString* ls = (OGRLineString*) OGRGeometryFactory::createGeometry(wkbLineString);
+    OGRLinearRing* lr = (OGRLinearRing*) OGRGeometryFactory::createGeometry(wkbLinearRing);
+    lr->addPoint(min[0], min[1], max[2]);
+    lr->addPoint(min[0], max[1], min[2]);
+    lr->addPoint(min[0], max[1], max[2]);
+    lr->addPoint(min[0], min[1], min[2]);
+    lr->addPoint(min[0], min[1], max[2]);
+    lr->addPoint(min[0], max[1], min[2]);
+    lr->addPoint(min[0], max[1], max[2]);
+    lr->addPoint(max[0], min[1], min[2]);
+    lr->addPoint(max[0], min[1], max[2]);
+    lr->addPoint(max[0], max[1], min[2]);
+    lr->addPoint(max[0], max[1], max[2]);
+    lr->closeRings();
+    poly->addRingDirectly(lr);
+}
+
+BOOST_AUTO_TEST_SUITE(spatial_index)
+    std::string dbfile = "test_sqlite.db";
+    BOOST_AUTO_TEST_CASE(spatial_index_1)
+    {
+        ODBStorage::Ptr storage = setUpStorage(dbfile, true);
+        Core core(storage);
+
+        SpatialIndex::Ptr index(new SpatialIndex());
+        core.addModule(index);
+
+        // add a spatial refernce
+        LocalCS::Ptr cs(new LocalCS());
+        core.addEntity(cs);
+
+        // add a few geometries, all with y/z from 0 to 1, but with different x:
+        // 0  1  2  3  4  5  6  7  8  9 10
+        // |p0|p1|p2|p3|p4|p5|p6|p7|p8|p9|
+        for (int i = 0; i < 10; i++)
+        {
+            Polygon::Ptr p( new Polygon(new PredefinedID("p" + std::to_string(i))) );
+            setupQuadrangle(p->geometry(), {{float(i), 0, 0}}, {{float(i+1), 1, 1}});
+            p->setCS(cs);
+            core.addEntity(p);
+        }
+
+        // add more geometries, with different coordinate systems!
+        LocalCS::Ptr previous = cs;
+        for (int i = 10; i < 20; i++)
+        {
+            Polygon::Ptr p( new Polygon(new PredefinedID("p" + std::to_string(i))) );
+            setupQuadrangle(p->geometry(), {{float(9), 0, 0}}, {{float(10), 1, 1}});   // always the same
+
+            LocalCS::Ptr child(new LocalCS());  // with a new coordinate system
+            child->setParent(previous);         // attached to the previous
+            child->setTranslation(1, 0, 0);     // with a fixed offset of x=1
+            core.addEntity(child);
+            previous = child;
+
+            p->setCS(child);
+            core.addEntity(p);
+        }
+
+        /** now we have 20 polygons side by side along the x axis, with the first 10 in the same
+            coordinate system, the last 10 chained with a const offset of 1.
+            0 ----------7  8  9 10  11  12  13 -------- 20
+            |p0|        |p7|p8|p9|p10|p11|p12|
+            let's query for everything
+                within [7.5, 12.5] --> expected 8,9,10,11
+                intersects ^^ --> expected 7,8,9,10,11,12
+        */
+        std::set<std::string> expected_within = {{ "p8", "p9", "p10", "p11" }};
+        std::set<std::string> expected_intersects = {{ "p7", "p8", "p9", "p10", "p11", "p12" }};
+
+        // within
+        auto query = SpatialIndexQuery::withinBox(Eigen::Vector3d{7.5, -1, -1}, Eigen::Vector3d{12.5, 2, 2}, cs);
+        core.answerQuery(query);
+
+        BOOST_CHECK_EQUAL(query->results.size(), expected_within.size());
+        for (auto r : query->results)
+        {
+            BOOST_CHECK( expected_within.find(r->id()) != expected_within.end() );
+        }
+
+        // intersects
+        query->results.clear();
+        query->mode(SpatialIndexQuery::INTERSECTS);
+        core.answerQuery(query);
+
+        BOOST_CHECK_EQUAL(query->results.size(), expected_intersects.size());
+        for (auto r : query->results)
+        {
+            BOOST_CHECK( expected_intersects.find(r->id()) != expected_intersects.end() );
+        }
+    }
+
+    BOOST_AUTO_TEST_CASE(spatial_index_cleanup)
+    {
+        removeStorage(dbfile);
+    }
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -116,7 +116,15 @@ int main(int argc, char** args)
          c.addEntity(p);
      }
 
-     spatial->test();
+
+     // query for everything in a box.
+     Eigen::Vector3d lower{-0.1, -0.1, -0.1};
+     Eigen::Vector3d upper{5.2, 1.2, 1.2};
+     auto q = SpatialIndexQuery::withinBox(lower, upper, cs);
+     c.answerQuery(q);
+     for (auto r : q->results) {
+         std::cout << "SpatialIndexQuery result: " << r->id() << '\n';
+     }
 
 
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -126,5 +126,13 @@ int main(int argc, char** args)
          std::cout << "SpatialIndexQuery result: " << r->id() << '\n';
      }
 
+     std::cout << "and inverted?" << '\n';
+     q->invert();
+     q->results.clear();
+     c.answerQuery(q);
+     for (auto r : q->results) {
+         std::cout << "SpatialIndexQuery result: " << r->id() << '\n';
+     }
+
 
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -9,6 +9,7 @@ using namespace sempr::entity;
 #include <sempr/processing/DBUpdateModule.hpp>
 #include <sempr/processing/ActiveObjectStore.hpp>
 #include <sempr/processing/SopranoModule.hpp>
+#include <sempr/processing/SpatialIndex.hpp>
 using namespace sempr::processing;
 
 #include <sempr/query/ObjectQuery.hpp>
@@ -33,6 +34,9 @@ using namespace sempr::query;
 #include <sempr/entity/spatial/LocalCS.hpp>
 
 #include <RDFDocument_odb.h>
+#include <Polygon_odb.h>
+
+#include <array>
 
 #ifndef M_PI
 #   define M_PI 3.141592653589793
@@ -47,47 +51,33 @@ void print(OGRGeometry* p)
 }
 
 
-// create a simple query
-class DummyQuery : public Query {
-public:
-    using Ptr = std::shared_ptr<DummyQuery>;
-    std::string type() const { return "DummyQuery"; }
-    int count;
-};
 
-// create a simple module that will just issue a sparql-query.
-class DummyModule : public Module {
-public:
-    using Ptr = std::shared_ptr<DummyModule>;
-    std::string type() const {
-        return "DummyModule";
-    }
+void setupQuadrangle(OGRPolygon* poly, const std::array<float, 3>& min, const std::array<float, 3>& max)
+{
+    // OGRLineString* ls = (OGRLineString*) OGRGeometryFactory::createGeometry(wkbLineString);
+    OGRLinearRing* lr = (OGRLinearRing*) OGRGeometryFactory::createGeometry(wkbLinearRing);
+    lr->addPoint(min[0], min[1], max[2]);
+    lr->addPoint(min[0], max[1], min[2]);
+    lr->addPoint(min[0], max[1], max[2]);
+    lr->addPoint(min[0], min[1], min[2]);
+    lr->addPoint(min[0], min[1], max[2]);
+    lr->addPoint(min[0], max[1], min[2]);
+    lr->addPoint(min[0], max[1], max[2]);
+    lr->addPoint(max[0], min[1], min[2]);
+    lr->addPoint(max[0], min[1], max[2]);
+    lr->addPoint(max[0], max[1], min[2]);
+    lr->addPoint(max[0], max[1], max[2]);
+    lr->closeRings();
+    poly->addRingDirectly(lr);
+}
 
-    DummyModule() {
-        addOverload<DummyQuery>(
-            [this] (DummyQuery::Ptr q) {
-                this->answerDummy(q);
-            }
-        );
-    }
 
-    void answerDummy(DummyQuery::Ptr query)
-    {
-        // just ask a sparql-query
-        SPARQLQuery::Ptr sparql(new SPARQLQuery());
-        sparql->query = "SELECT * WHERE { ?s ?p ?o . }";
-        this->ask(sparql);
-        // result of DummyQuery is the number of results of the sparql query
-        query->count = sparql->results.size();
-    }
-};
 
 int main(int argc, char** args)
 {
-
-    RDFDocument::FromFile("model.owl");
-
-
+    /* ************* *
+     * SETUP
+     * ************** */
     // ODBStorage::Ptr storage( new ODBStorage(":memory:") );
     ODBStorage::Ptr storage( new ODBStorage() );
 
@@ -95,6 +85,7 @@ int main(int argc, char** args)
     DBUpdateModule::Ptr updater( new DBUpdateModule(storage) );
     ActiveObjectStore::Ptr active( new ActiveObjectStore() );
     SopranoModule::Ptr semantic( new SopranoModule() );
+    SpatialIndex::Ptr spatial( new SpatialIndex() );
 
     sempr::core::IDGenerator::getInstance().setStrategy(
         // std::unique_ptr<sempr::core::UUIDGeneration>( new sempr::core::UUIDGeneration(false) )
@@ -106,23 +97,26 @@ int main(int argc, char** args)
     c.addModule(debug);
     c.addModule(updater);
     c.addModule(semantic);
+    c.addModule(spatial);
 
 
-    /********************************
-        test query-within-query
-    **********************************/
-    DummyModule::Ptr module(new DummyModule());
-    c.addModule(module);
+    /* ************* *
+     * TESTS
+     * ************** */
+     // add a spatial refernce
+     LocalCS::Ptr cs(new LocalCS());
+     c.addEntity(cs);
 
-    DummyQuery::Ptr query(new DummyQuery());
-    c.answerQuery(query);
-    std::cout << query->count << '\n';
+     // add a few geometries
+     for (float i = 0.1; i < 10; i++)
+     {
+         Polygon::Ptr p( new Polygon() );
+         setupQuadrangle(p->geometry(), {{i, 0, 0}}, {{i+1, 1, 1}});
+         p->setCS(cs);
+         c.addEntity(p);
+     }
 
-    // add some rdf-stuff
-    Person::Ptr p(new Person());
-    c.addEntity(p);
+     spatial->test();
 
-    c.answerQuery(query);
-    std::cout << query->count << '\n';
 
 }


### PR DESCRIPTION
This PR adds a simple SpatialIndex-processing-module based on the RTree implementation in `boost::geometry::index`.

Currently, the SpatialIndex assumes that all geometries a located in a reference frame with the same root, and in that system the index operates. That means, whenever a geometry is added or it or a spatial reference which affects it is changed, we do the following:
1. Take the Envelope3D of the OGRGeometry
2. Construct a GeometryCollection with 8 corner-points from the Envelope3D
3. Transform the GeometryCollection into the root-reference-frame
4. Take the Envelope3D of the GeometryCollection
5. Use that in the index.
This may sound overly complex, but think about it: The chain of coordinate systems may include rotations which make a former AABB unaligned/oriented. But the index only works on AABBs, so we take the extra step of creating one. And since we don't want to transform a possibly huge geometry into the root frame, we take its AABB first, transform it, and make it AA again.

### What is left todo?
The predicate **contains** could be nice, but is not available in boost 1.54, only since 1.55. But on my particular system ros-indigo prevents the update.

Also: remove the above mentioned assumption. Give the SpatialIndex a reference frame for which it should be responsible, and let it ignore all geometries that can not be transformed to it / are not within a child-frame of it.