### PR TITLE
Core::getModule<T> and Core::listModules<T>

### DIFF
--- a/include/sempr/core/Core.hpp
+++ b/include/sempr/core/Core.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace sempr { namespace core {
 
@@ -23,7 +24,41 @@ public:
     void removeEntity(entity::Entity::Ptr entity);
 
 
+    /**
+        Adds a module to the core, thus connecting it to events and queries.
+    */
     void addModule(processing::ModuleBase::Ptr module);
+
+    /**
+        Returns the first added instance of the given module type.
+        Does not remove the module from the core.
+        \returns nullptr if no module of that type is present in the core
+    */
+    template <class ModuleType>
+    std::shared_ptr<ModuleType> getModule()
+    {
+        for (auto m : modules_)
+        {
+            auto module = std::dynamic_pointer_cast<ModuleType>(m);
+            if (module) return module;
+        }
+        return nullptr;
+    }
+
+    /**
+        Returns a vector of all instances of the given module type.
+        Does not remove the modules from the core.
+    */
+    template <class ModuleType>
+    void listModules(std::vector<std::shared_ptr<ModuleType>>& list)
+    {
+        for (auto m : modules_)
+        {
+            auto module = std::dynamic_pointer_cast<ModuleType>(m);
+            if (module) list.push_back(module);
+        }
+    }
+
 
     /**
         Let the core handle a query: Forwards the query to every module.

--- a/test/storage_tests.cpp
+++ b/test/storage_tests.cpp
@@ -27,6 +27,14 @@ BOOST_AUTO_TEST_SUITE(general_tests)
     core.addModule(active);
     core.addModule(updater);
 
+    auto module = core.getModule<DBUpdateModule>();
+    BOOST_CHECK_EQUAL(module, updater);
+
+    std::vector<ActiveObjectStore::Ptr> mlist;
+    core.listModules(mlist);
+    BOOST_CHECK_EQUAL(mlist.size(), 1);
+    BOOST_CHECK_EQUAL(mlist[0], active);
+
     removeStorage(db_path);
   }
 


### PR DESCRIPTION
Added methods to access ProcessingModules that have already been added to the core:
- `T::Ptr Core::getModule<T>()` returns the first module of the given type that was added to the core
- `void Core::listModules<T>(std::vector<T::Ptr>&)` fills a given vector with all modules of matching type that were added to the core