### PR TITLE
WIP: LoadingQuery

### DIFF
--- a/include/sempr/processing/DBUpdateModule.hpp
+++ b/include/sempr/processing/DBUpdateModule.hpp
@@ -7,6 +7,7 @@
 #include <sempr/processing/Module.hpp>
 #include <sempr/storage/Storage.hpp>
 #include <sempr/entity/Entity.hpp>
+#include <sempr/query/LoadingQuery.hpp>
 #include <vector>
 
 namespace sempr { namespace processing {
@@ -35,7 +36,8 @@ namespace sempr { namespace processing {
 
     TODO: Add functionality to allow the user bulk-creation of entities, on his own risk. Something like "DBUpdateModule::enableBulkCreation(bool)".
 */
-class DBUpdateModule : public Module<core::EntityEvent<entity::Entity>> {
+class DBUpdateModule : public Module<core::EntityEvent<entity::Entity>,
+                                     query::LoadingQueryBase> {
 public:
     using Ptr = std::shared_ptr<DBUpdateModule>;
     DBUpdateModule(storage::Storage::Ptr storage);
@@ -43,6 +45,8 @@ public:
     /** upon receiving a changed-event, update the database */
     void process(core::EntityEvent<entity::Entity>::Ptr e) override;
 
+    /** loads entities from the database */
+    void process(query::LoadingQueryBase::Ptr query) override;
 
     /** save the changed and erase the entities flagged for removal */
     void updateDatabase();

--- a/include/sempr/query/LoadingQuery.hpp
+++ b/include/sempr/query/LoadingQuery.hpp
@@ -1,0 +1,47 @@
+#ifndef SEMPR_QUERY_LOADINGQUERY_HPP_
+#define SEMPR_QUERY_LOADINGQUERY_HPP_
+
+#include <sempr/query/Query.hpp>
+#include <sempr/storage/ODBStorage.hpp>
+#include <odb/core.hxx>
+#include <memory>
+
+namespace sempr { namespace query {
+
+    /**
+        Loading-Queries are used to tell the DBUpdateModule to load certain entities from the
+        database.
+
+        NOTE: Sadly it only works with ODBStorage! There can be no virtual template methods...
+    */
+    class LoadingQueryBase : public Query, public core::OType<LoadingQueryBase> {
+    public:
+        using Ptr = std::shared_ptr<LoadingQueryBase>;
+        virtual ~LoadingQueryBase(){}
+        std::string type() const override { return "LoadingQuery"; }
+
+        virtual void loadFrom(storage::ODBStorage::Ptr storage) = 0;
+    };
+
+
+    /**
+        Query for all objects of the type specified as template parameter.
+
+        TODO: Optional parameter for search-criteria? "Load only persons older than..." should be possible
+    */
+    template <class T>
+    class LoadingQuery : public LoadingQueryBase, public core::OType<LoadingQuery<T>> {
+    public:
+        using Ptr = std::shared_ptr<LoadingQuery<T> >;
+        std::vector<std::shared_ptr<T> > results;
+
+        void loadFrom(storage::ODBStorage::Ptr storage) override
+        {
+            storage->loadAll(this->results);
+        }
+
+    };
+
+}}
+
+#endif /* end of include guard: SEMPR_QUERY_LOADINGQUERY_HPP_ */

--- a/src/processing/DBUpdateModule.cpp
+++ b/src/processing/DBUpdateModule.cpp
@@ -2,6 +2,8 @@
 #include <sempr/core/Exception.hpp>
 #include <iostream>
 
+#include <sempr/storage/ODBStorage.hpp>
+
 namespace sempr { namespace processing {
 
 DBUpdateModule::DBUpdateModule(storage::Storage::Ptr storage)
@@ -29,6 +31,17 @@ void DBUpdateModule::process(core::EntityEvent<entity::Entity>::Ptr e)
   }
 }
 
+
+void DBUpdateModule::process(query::LoadingQueryBase::Ptr query)
+{
+    // its simple: just use it on the storage.
+    // but it *must be* an ODB storage. oh man... :-/
+    // TODO: remove the "storage" interface and just make ODBStorage a key component of sempr?
+    auto odb = std::dynamic_pointer_cast<storage::ODBStorage>(storage_);
+    if (odb) {
+        query->loadFrom(odb);
+    }
+}
 
 void DBUpdateModule::registerAdded(storage::DBObject::Ptr obj)
 {

--- a/test/storage_tests.cpp
+++ b/test/storage_tests.cpp
@@ -1,5 +1,7 @@
+#include <sempr/query/LoadingQuery.hpp>
 #include "test_utils.hpp"
 using namespace testing;
+
 
 BOOST_AUTO_TEST_SUITE(general_tests)
 
@@ -124,6 +126,41 @@ BOOST_AUTO_TEST_CASE(retrieval){
     removeStorage(db_path);
   }
 }
+
+
+BOOST_AUTO_TEST_CASE(loading_query){
+    // add some entities
+    {
+        ODBStorage::Ptr storage = setUpStorage(db_path, true);
+        DBUpdateModule::Ptr updater(new DBUpdateModule(storage));
+        Core core;
+        core.addModule(updater);
+
+        for (int i = 0; i < 10; i++)
+        {
+            Person::Ptr person(new Person());
+            core.addEntity(person);
+        }
+
+        updater->updateDatabase();
+    }
+
+    // test the query
+    {
+        //core created anew to force a new session, retrieve entity"
+        ODBStorage::Ptr storage = loadStorage(db_path);
+        DBUpdateModule::Ptr updater(new DBUpdateModule(storage));
+        Core core;
+        core.addModule(updater);
+
+        auto q = std::make_shared<LoadingQuery<Person>>();
+        core.answerQuery(q);
+        BOOST_CHECK_EQUAL(q->results.size(), 10);   // 10 persons
+
+        removeStorage(db_path);
+    }
+}
+
 
 BOOST_AUTO_TEST_CASE(update) {
   //DBUpdateModule::Ptr updater( new DBUpdateModule(storage) );


### PR DESCRIPTION
This PR adds a `LoadingQuery` which can be used to load entities from a database. It is handled by the DBUpdateModule.

This is still work in progress, because:
- I don't like the fact that I need to dynamic_cast the Storage to an ODBStorage for this to work
- I'd like to add a way to further customize the query, similar to ObjectQuery's decision function.