### PR TITLE
added RDFValue::operator == (const T&)

### DIFF
--- a/include/sempr/entity/RDFValue.hpp
+++ b/include/sempr/entity/RDFValue.hpp
@@ -122,8 +122,6 @@ public:
         static_assert(std::is_base_of<Entity, T>::value, "Type not derived from Entity");
         type_ = Type::POINTER;
         pointer_ = other;
-        // TODO: need a central point of namespace definitions
-        // stringRepresentation_ = ("<" + std::string("sempr://") + pointer_->id() + ">");
         Soprano::Node tmp = Soprano::Node::createResourceNode(
             QUrl(QString::fromStdString(sempr::baseURI() + pointer_->id()))
         );
@@ -133,6 +131,23 @@ public:
 
     // overload for c-strings (so that map["name"]="Max" wont result in "true"^^<xsd:boolean>)
     RDFValue& operator = (const char* cstr);
+
+    /** Comparison with actual type */
+    template <typename T>
+    bool operator == (const T& other) {
+        return this->get<T>() == other;
+    }
+
+    /**
+        Specialization (actually: Overload!) for comparison with c strings. Without this, trying to
+        do:
+            bool ok = (map["key"] == "Hello, World!");
+        will cause the compiler to try to cast this RDFValue to char[14].
+    */
+    bool operator == (const char* other) {
+        return this->get<std::string>() == other;
+    }
+
 
     /** Casts. Delegates to "to<T>()" since the operators syntax doesn't allow
         for enable_if<...> - differentiation
@@ -145,7 +160,7 @@ public:
 
     /** Just another way to cast. */
     template <typename T>
-    T get() const {
+    T get() {
         return *this;
     }
 

--- a/include/sempr/entity/RDFValue.hpp
+++ b/include/sempr/entity/RDFValue.hpp
@@ -138,6 +138,35 @@ public:
         return this->get<T>() == other;
     }
 
+    template <typename T>
+    bool operator != (const T& other) {
+        return !(this->get<T>() == other);
+    }
+
+
+    template <typename T>
+    bool operator < (const T& other) {
+        return this->get<T>() < other;
+    }
+
+    template <typename T>
+    bool operator <= (const T& other) {
+        return this->get<T>() <= other;
+    }
+
+    template <typename T>
+    bool operator > (const T& other) {
+        return this->get<T>() > other;
+    }
+
+    template <typename T>
+    bool operator >= (const T& other) {
+        return this->get<T>() >= other;
+    }
+
+
+
+
     /**
         Specialization (actually: Overload!) for comparison with c strings. Without this, trying to
         do:
@@ -147,6 +176,27 @@ public:
     bool operator == (const char* other) {
         return this->get<std::string>() == other;
     }
+
+    bool operator != (const char* other) {
+        return !(this->operator ==(other));
+    }
+    
+    bool operator < (const char* other) {
+        return this->get<std::string>() < other;
+    }
+
+    bool operator <= (const char* other) {
+        return this->get<std::string>() <= other;
+    }
+
+    bool operator > (const char* other) {
+        return this->get<std::string>() > other;
+    }
+
+    bool operator >= (const char* other) {
+        return this->get<std::string>() >= other;
+    }
+
 
 
     /** Casts. Delegates to "to<T>()" since the operators syntax doesn't allow

--- a/test/RDFPropertymap_tests.cpp
+++ b/test/RDFPropertymap_tests.cpp
@@ -54,6 +54,20 @@ BOOST_AUTO_TEST_SUITE(entity_RDFPropertyMap)
         ok = m["float"] == 1.234f;
         BOOST_CHECK(ok);
         // ----------------
+        BOOST_CHECK( (m["int"] < 100) );
+        BOOST_CHECK( (m["int"] >  40) );
+        BOOST_CHECK( (m["int"] <= 42) );
+        BOOST_CHECK( (m["int"] <= 43) );
+        BOOST_CHECK(!(m["int"] <= 10) );
+        BOOST_CHECK( (m["int"] >= 10) );
+        BOOST_CHECK( (m["int"] !=  7) );
+        BOOST_CHECK(!(m["int"] != 42) );
+        BOOST_CHECK( (m["string"] < "ZZZ") );
+        BOOST_CHECK( (m["string"] > "AAA") );
+        BOOST_CHECK(!(m["string"] != "Hello, World!") );
+
+
+
 
         // create another entity and point to it.
         Person::Ptr person(new Person());

--- a/test/RDFPropertymap_tests.cpp
+++ b/test/RDFPropertymap_tests.cpp
@@ -33,6 +33,28 @@ BOOST_AUTO_TEST_SUITE(entity_RDFPropertyMap)
         BOOST_CHECK( m.hasProperty("float") );
         m["string"] = "Hello, World!";
 
+        // conversions from/to strings are sometimes a bit buggy, at a compiler level.
+        // these are a few tests added for issue #30
+        std::string foo = m["string"]; // was no problem. copy constructor of string is used
+        std::string bar;
+        // bar = m["string"]; // this won't compile, the assignment operator is ambiguous here
+        bar = m["string"].get<std::string>(); // but this works as the desired type is stated explicitely
+        BOOST_CHECK_EQUAL(bar, "Hello, World!");
+        // another problem was the fact that the operator == wasn't implemented. This should be okay now, too. The comments describe the error before implementing the operator.
+        bool ok;
+        ok = m["string"] == std::string("Hello, World!");  // invalid operands to binary expression
+        BOOST_CHECK(ok);
+
+        ok = m["string"] == "Hello, World!"; // interestingly, this was only a warning but seems to work!
+        BOOST_CHECK(ok);
+        ok = m["string"] == "Something wrong.";
+        BOOST_CHECK(!ok);
+        ok = m["int"] == 42; // invalid operands to binary expression
+        BOOST_CHECK(ok);
+        ok = m["float"] == 1.234f;
+        BOOST_CHECK(ok);
+        // ----------------
+
         // create another entity and point to it.
         Person::Ptr person(new Person());
         core.addEntity(person);


### PR DESCRIPTION
This fixes #30 as good as possible, I think:

The first part of the issue cannot be resolved so easily, since I have no influence on the the assignment operator of `std::string`, which accepts different types, so that the compiler does not know which type it should cast our `RDFValue` to. The solution is to use the `template <class T> RDFValue::get()` method here (which is **not** new, but now works due to the removed _const_):
```c++
std::string foo = map["key"]; // no problem (copy ctor)
// foo = map["key"]; // does not work, ambiguous (assignment operator)
foo = map["key"].get<std::string>(); // works (assignment operator) since we explicitly specify the type to cast to
```

The second part of the issue has to do with comparing values to entries in the `RDFPropertyMap`. I simply added the `template <class T> RDFValue::operator == (const T&)` which casts to `T` and compares the result with the given value. With one exception to correctly compare with `const char*`.