### PR TITLE
fix a bunch of warnings

### DIFF
--- a/include/sempr/entity/spatial/filter/GeocentricFilter.hpp
+++ b/include/sempr/entity/spatial/filter/GeocentricFilter.hpp
@@ -34,13 +34,13 @@ class GeocentricException : public std::exception
 class ECEFFilter : public geom::CoordinateSequenceFilter
 {
 public:
-    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i);
+    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i) override;
 
     void filter_ro(const geom::CoordinateSequence& seq, std::size_t i) override;
 
-    bool isDone() const;
+    bool isDone() const override;
 
-    bool isGeometryChanged() const;
+    bool isGeometryChanged() const override;
 protected:
     ECEFFilter(double a, double f);
 
@@ -69,13 +69,13 @@ public:
 class LTGFilter : public geom::CoordinateSequenceFilter
 {
 public:
-    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i);
+    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i) override;
 
     void filter_ro(const geom::CoordinateSequence& seq, std::size_t i) override;
 
-    bool isDone() const;
+    bool isDone() const override;
 
-    bool isGeometryChanged() const;
+    bool isGeometryChanged() const override;
 protected:
     LTGFilter(double lat0, double lon0, double h0, double a, double f);
 

--- a/include/sempr/entity/spatial/filter/ProjectionFilter.hpp
+++ b/include/sempr/entity/spatial/filter/ProjectionFilter.hpp
@@ -52,13 +52,13 @@ class ProjectionZoneMissmatch : public std::exception
 class UTMFilter : public geom::CoordinateSequenceFilter
 {
 public:
-    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i);
+    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i) override;
 
     void filter_ro(const geom::CoordinateSequence& seq, std::size_t i) override;
 
-    bool isDone() const;
+    bool isDone() const override;
 
-    bool isGeometryChanged() const;
+    bool isGeometryChanged() const override;
 
 protected:
     UTMFilter(double a, double f, double k0, int zone, bool north);
@@ -98,13 +98,13 @@ public:
 class UPSFilter : public geom::CoordinateSequenceFilter
 {
 public:
-    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i);
+    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i) override;
 
     void filter_ro(const geom::CoordinateSequence& seq, std::size_t i) override;
 
-    bool isDone() const;
+    bool isDone() const override;
 
-    bool isGeometryChanged() const;
+    bool isGeometryChanged() const override;
 
 protected:
     UPSFilter(double a, double f, double k0, bool north);
@@ -138,13 +138,13 @@ public:
 class MGRSFilter : public geom::CoordinateSequenceFilter
 {
 public:
-    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i);
+    virtual void filter_rw(geom::CoordinateSequence& seq, std::size_t i) override;
 
     void filter_ro(const geom::CoordinateSequence& seq, std::size_t i) override;
 
-    bool isDone() const;
+    bool isDone() const override;
 
-    bool isGeometryChanged() const;
+    bool isGeometryChanged() const override;
 
 protected:
     MGRSFilter(const std::string& GZDSquareID);   //only WGS84!

--- a/include/sempr/entity/spatial/reference/EarthCenteredCS.hpp
+++ b/include/sempr/entity/spatial/reference/EarthCenteredCS.hpp
@@ -23,9 +23,9 @@ public:
 
 protected:
 
-    virtual FilterPtr forward() const;
+    virtual FilterPtr forward() const override;
 
-    virtual FilterPtr reverse() const;
+    virtual FilterPtr reverse() const override;
 
 private:
     friend class odb::access;

--- a/include/sempr/entity/spatial/reference/GeocentricCS.hpp
+++ b/include/sempr/entity/spatial/reference/GeocentricCS.hpp
@@ -18,13 +18,13 @@ class GeocentricCS : public GlobalCS {
 public:
     using Ptr = std::shared_ptr<GeocentricCS>;
 
-    virtual FilterList to(const GlobalCS::Ptr other);
+    virtual FilterList to(const GlobalCS::Ptr other) override;
 
 protected:
 
-    virtual FilterPtr forward() const;
+    virtual FilterPtr forward() const override;
 
-    virtual FilterPtr reverse() const;
+    virtual FilterPtr reverse() const override;
 
 
     GeocentricCS();

--- a/include/sempr/entity/spatial/reference/LocalTangentPlaneCS.hpp
+++ b/include/sempr/entity/spatial/reference/LocalTangentPlaneCS.hpp
@@ -26,9 +26,9 @@ public:
 protected:
     LocalTangentPlaneCS();
 
-    virtual FilterPtr forward() const;
+    virtual FilterPtr forward() const override;
 
-    virtual FilterPtr reverse() const;
+    virtual FilterPtr reverse() const override;
 
 private:
     friend class odb::access;

--- a/include/sempr/entity/spatial/reference/MilitaryGridReferenceSystem.hpp
+++ b/include/sempr/entity/spatial/reference/MilitaryGridReferenceSystem.hpp
@@ -18,7 +18,7 @@ public:
     using Ptr = std::shared_ptr<MilitaryGridReferenceSystem>;
 
     MilitaryGridReferenceSystem(const std::string& GZDSquareID);    //eg. 4QFJ
-    MilitaryGridReferenceSystem(int zone, char designator, const std::string& squareID);  
+    MilitaryGridReferenceSystem(int zone, char designator, const std::string& squareID);
     MilitaryGridReferenceSystem(int zone, char designator, const std::string& squareID, const core::IDGenBase*);
 
     bool isEqual(const GlobalCS::Ptr other) override;
@@ -35,9 +35,9 @@ public:
 protected:
     MilitaryGridReferenceSystem();
 
-    virtual FilterPtr forward() const;
+    virtual FilterPtr forward() const override;
 
-    virtual FilterPtr reverse() const;
+    virtual FilterPtr reverse() const override;
 
     static int zoneFromGZD(const std::string& GZDSquareID);
     static char designatorFromGZD(const std::string& GZDSquareID);

--- a/include/sempr/entity/spatial/reference/ProjectionCS.hpp
+++ b/include/sempr/entity/spatial/reference/ProjectionCS.hpp
@@ -22,7 +22,7 @@ class ProjectionCS : public GlobalCS {
 public:
     using Ptr = std::shared_ptr<ProjectionCS>;
 
-    virtual FilterList to(const GlobalCS::Ptr other);
+    virtual FilterList to(const GlobalCS::Ptr other) override;
 
     virtual int getZone() const;
     virtual bool isNorth() const;
@@ -38,8 +38,8 @@ public:
 
 protected:
 
-    virtual FilterPtr forward() const;
-    virtual FilterPtr reverse() const;
+    virtual FilterPtr forward() const override;
+    virtual FilterPtr reverse() const override;
 
     ProjectionCS();
     ProjectionCS(const core::IDGenBase*);

--- a/include/sempr/entity/spatial/reference/UniversalPolarStereographicCS.hpp
+++ b/include/sempr/entity/spatial/reference/UniversalPolarStereographicCS.hpp
@@ -28,9 +28,9 @@ public:
 protected:
     UniversalPolarStereographicCS();
 
-    virtual FilterPtr forward() const;
+    virtual FilterPtr forward() const override;
 
-    virtual FilterPtr reverse() const;
+    virtual FilterPtr reverse() const override;
 
 private:
     friend class odb::access;

--- a/include/sempr/entity/spatial/reference/UniversalTransverseMercatorCS.hpp
+++ b/include/sempr/entity/spatial/reference/UniversalTransverseMercatorCS.hpp
@@ -28,9 +28,9 @@ public:
 protected:
     UniversalTransverseMercatorCS();
 
-    virtual FilterPtr forward() const;
+    virtual FilterPtr forward() const override;
 
-    virtual FilterPtr reverse() const;
+    virtual FilterPtr reverse() const override;
 
 private:
     friend class odb::access;

--- a/src/entity/spatial/reference/GlobalCS.cpp
+++ b/src/entity/spatial/reference/GlobalCS.cpp
@@ -24,7 +24,11 @@ GlobalCS::~GlobalCS()
 
 bool GlobalCS::isEqual(const GlobalCS::Ptr other)
 {
-    return typeid(*other) == typeid(*this);
+    // avoid expr. side effects warning:
+    auto& tmpOther = *other;
+    auto& tmpThis = *this;
+    
+    return typeid(tmpOther) == typeid(tmpThis);
 }
 
 SpatialReference::Ptr GlobalCS::getRoot()

--- a/src/entity/spatial/reference/MilitaryGridReferenceSystem.cpp
+++ b/src/entity/spatial/reference/MilitaryGridReferenceSystem.cpp
@@ -180,7 +180,7 @@ bool MilitaryGridReferenceSystem::checkGZD(const std::string& GZDSquareID)
         return false;
 
     std::string squareID = squareIDFromGZD(GZDSquareID);
-    if (squareID.size() < 0 || squareID.size() > 2)
+    if (squareID.size() > 2)
         return false;
 
     return true;

--- a/test/spatial_index_tests.cpp
+++ b/test/spatial_index_tests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(spatial_index)
         //build up a quadrangle
         LocalCS::Ptr cs(new LocalCS());
         MultiPoint::Ptr mp( new MultiPoint() );
-        mp->setGeometry(setupQuadrangle({1, 1, 1}, {10, 10, 10}));
+        mp->setGeometry(setupQuadrangle({{1, 1, 1}}, {{10, 10, 10}}));
         mp->setCS(cs);
         core.addEntity(mp);
 


### PR DESCRIPTION
While using sempr in another project, I noticed that clang shows me quite a lot of warnings, which g++ _should_ show me, too, but curiously doesn't (despite the -Wall flag).

A lot of them were missing `override` keywords in the new coordinate system code. So I just compiled sempr with clang++ and added the missing keywords. :)

But some warnings remain, which I did not address yet -- maybe **you** want to fix them, @ctieben?

```
sempr/src/entity/spatial/reference/MilitaryGridReferenceSystem.cpp:183:25: warning: comparison of unsigned expression < 0 is always     false [-Wtautological-compare]
       if (squareID.size() < 0 || squareID.size() > 2)
           ~~~~~~~~~~~~~~~ ^ ~
   1 warning generated.
   sempr/src/entity/spatial/reference/GlobalCS.cpp:27:19: warning: expression with side effects will be evaluated despite being used a    s an operand to 'typeid' [-Wpotentially-evaluated-expression]
       return typeid(*other) == typeid(*this);
                     ^
   1 warning generated.
  sempr/test/spatial_index_tests.cpp:37:42: warning: suggest braces around initialization of subobject [-Wmissing-braces]
           mp->setGeometry(setupQuadrangle({1, 1, 1}, {10, 10, 10}));
                                            ^~~~~~~
                                            {      }
  sempr/test/spatial_index_tests.cpp:37:53: warning: suggest braces around initialization of subobject [-Wmissing-braces]
          mp->setGeometry(setupQuadrangle({1, 1, 1}, {10, 10, 10}));
                                                      ^~~~~~~~~~
```

(Though I must admit that the missing braces are probably my fault.)