### PR TITLE
Fix WKB export for 3D Geometries

### DIFF
--- a/src/entity/spatial/Geometry.cpp
+++ b/src/entity/spatial/Geometry.cpp
@@ -194,6 +194,9 @@ std::basic_string<char> Geometry::exportToWKB(const geom::Geometry* geom)
 {
     auto wkbWriter = geos::io::WKBWriter();
 
+    auto dim = geom->getCoordinateDimension();
+    wkbWriter.setOutputDimension(dim);
+
     std::basic_ostringstream<char> oss;
 
     try {

--- a/test/PointCloud_tests.cpp
+++ b/test/PointCloud_tests.cpp
@@ -145,6 +145,8 @@ BOOST_AUTO_TEST_SUITE(pointcloud)
         pc->at(0).x = 7;    //direct geom access to change coordinate
         (*pc)[0]->x() = 5;  //abstract way to access the coordinate
 
+        pc->at(1).z = 42;
+
         auto& i = pc->getChannelFloat(ChannelType::I);
         i[0] = 0.5;
 
@@ -189,6 +191,8 @@ BOOST_AUTO_TEST_SUITE(pointcloud)
         BOOST_CHECK_EQUAL(i[0], clouds[0]->getChannel<float>(ChannelType::I)[0]);
 
         BOOST_CHECK_EQUAL(clouds[0]->at(0).x, 5);
+
+        BOOST_CHECK_EQUAL(clouds[0]->at(1).z, 42);
     }
 
     BOOST_AUTO_TEST_CASE(pointcloud_cleanup)


### PR DESCRIPTION
Fix the issue that GEOS only export 2D geometries as WKB by default. So there was no Z coordinates in the DB if the geometry was stored as WKB.