### PR TITLE
Soprano reasoning optional

### DIFF
--- a/include/sempr/entity/spatial/SpatialObject.hpp
+++ b/include/sempr/entity/spatial/SpatialObject.hpp
@@ -49,6 +49,16 @@ public:
     /** return the type with highest confidence, optionally return the confidence in the given pointer */
     std::string type(double* confidence = nullptr) const;
 
+    /**
+        Clear all type information.
+    */
+    void clearTypes();
+
+    /**
+        Returns all type information in a map.
+    */
+    std::map<std::string, double> getTypes() const;
+
     /** set the confidence for a given type */
     void type(const std::string&, double confidence);
 

--- a/include/sempr/processing/SopranoModule.hpp
+++ b/include/sempr/processing/SopranoModule.hpp
@@ -24,7 +24,7 @@ namespace sempr { namespace processing {
                          query::SPARQLQuery > {
     public:
         using Ptr = std::shared_ptr<SopranoModule>;
-        SopranoModule();
+        SopranoModule(bool reasoning = true);
         ~SopranoModule();
 
         std::string type() const override { return "SopranoModule"; }
@@ -45,9 +45,9 @@ namespace sempr { namespace processing {
         void process(query::SPARQLQuery::Ptr query) override;
 
         /**
-            Set if soprano shall be used for reasoning. Default is "false".
+            Set if soprano shall be used for reasoning. Default is "true".
         */
-        void enableReasoning(bool);
+        bool reasoningEnabled();
 
     private:
         /// all updates take place inside the base model
@@ -58,7 +58,7 @@ namespace sempr { namespace processing {
         /// triggers a performInference
         bool dirty_;
 
-        bool reasoningEnabled_;
+        const bool reasoningEnabled_;
 
         /// a mapping between RuleSet-entities (string id) and their rules
         std::map<std::string, std::vector<Soprano::Inference::Rule> > ruleMap_;

--- a/include/sempr/processing/SopranoModule.hpp
+++ b/include/sempr/processing/SopranoModule.hpp
@@ -44,6 +44,11 @@ namespace sempr { namespace processing {
         */
         void process(query::SPARQLQuery::Ptr query) override;
 
+        /**
+            Set if soprano shall be used for reasoning. Default is "false".
+        */
+        void enableReasoning(bool);
+
     private:
         /// all updates take place inside the base model
         Soprano::Model* model_;
@@ -52,6 +57,8 @@ namespace sempr { namespace processing {
         /// if model and infmodel are out of sync, this flag is set and the next sparqlquery
         /// triggers a performInference
         bool dirty_;
+
+        bool reasoningEnabled_;
 
         /// a mapping between RuleSet-entities (string id) and their rules
         std::map<std::string, std::vector<Soprano::Inference::Rule> > ruleMap_;

--- a/include/sempr/processing/SopranoModule.hpp
+++ b/include/sempr/processing/SopranoModule.hpp
@@ -45,7 +45,7 @@ namespace sempr { namespace processing {
         void process(query::SPARQLQuery::Ptr query) override;
 
         /**
-            Set if soprano shall be used for reasoning. Default is "true".
+            Get true if soprano is used for reasoning. Default is "true".
         */
         bool reasoningEnabled();
 

--- a/src/entity/spatial/SpatialObject.cpp
+++ b/src/entity/spatial/SpatialObject.cpp
@@ -55,6 +55,19 @@ void SpatialObject::type(const std::string& type, double confidence)
     property_->changed();
 }
 
+void SpatialObject::clearTypes()
+{
+    types_.clear();
+    // (*property_)("type", core::rdf::baseURI()) = RDFResource("<" + this->type() + ">");
+    property_->removeProperty("type", core::rdf::baseURI());
+    property_->changed();
+}
+
+std::map<std::string, double> SpatialObject::getTypes() const
+{
+    return types_;
+}
+
 
 unsigned int SpatialObject::lastSeen() const
 {

--- a/src/processing/SopranoModule.cpp
+++ b/src/processing/SopranoModule.cpp
@@ -5,9 +5,9 @@
 
 namespace sempr { namespace processing {
 
-SopranoModule::SopranoModule()
+SopranoModule::SopranoModule(bool reasoning) :
+    reasoningEnabled_(reasoning)
 {
-    reasoningEnabled_ = false;
     model_ = Soprano::createModel();
     infmodel_ = new Soprano::Inference::InferenceModel(model_);
 }
@@ -19,9 +19,9 @@ SopranoModule::~SopranoModule()
 }
 
 
-void SopranoModule::enableReasoning(bool reason)
+bool SopranoModule::reasoningEnabled()
 {
-    reasoningEnabled_ = reason;
+    return reasoningEnabled_;
 }
 
 void SopranoModule::process(core::EntityEvent<entity::RDFEntity>::Ptr event)

--- a/test/queries_tests.cpp
+++ b/test/queries_tests.cpp
@@ -74,7 +74,6 @@ BOOST_AUTO_TEST_SUITE(queries)
         SopranoModule::Ptr semantic(new SopranoModule());
         core.addModule(active);
         core.addModule(semantic);
-        semantic->enableReasoning(true);
 
         // query anything, there should be nothing
         {

--- a/test/queries_tests.cpp
+++ b/test/queries_tests.cpp
@@ -74,6 +74,7 @@ BOOST_AUTO_TEST_SUITE(queries)
         SopranoModule::Ptr semantic(new SopranoModule());
         core.addModule(active);
         core.addModule(semantic);
+        semantic->enableReasoning(true);
 
         // query anything, there should be nothing
         {


### PR DESCRIPTION
Make the reasoning of the soprano module optional to allow a alternative reasoner.