### PR TITLE
feature: CallbackModule

### DIFF
--- a/include/sempr/processing/CallbackModule.hpp
+++ b/include/sempr/processing/CallbackModule.hpp
@@ -1,0 +1,57 @@
+#ifndef SEMPR_PROCESSING_CALLBACK_MODULE_HPP_
+#define SEMPR_PROCESSING_CALLBACK_MODULE_HPP_
+
+
+#include "Module.hpp"
+#include "../core/Observable.hpp"
+#include "../core/Utility.hpp"
+#include <functional>
+
+namespace sempr {
+namespace processing {
+
+
+/**
+    The CallbackModule is a convenience module to easily allow adding simple callback functions
+    to react to changes on one specific type of entity.
+    Instantiate it with a callback, e.g. a lambda function, which takes a shared_ptr to an
+    ObservableType as input, e.g. an EntityEvent<...>.
+*/
+template <class ObservableType>
+class CallbackModule : public Module<ObservableType> {
+public:
+    typedef std::function<void(std::shared_ptr<ObservableType>)> callback_t;
+    callback_t callback_;
+public:
+    using Ptr = std::shared_ptr<CallbackModule>;
+
+    CallbackModule(callback_t callback)
+        : callback_(callback)
+    {
+    }
+
+protected:
+    void process(std::shared_ptr<ObservableType> observable) override
+    {
+        if (callback_) callback_(observable);
+    }
+};
+
+// convenience helper to deduce template parameters
+template <class Func, // functor/function/member function/lambda given
+          class FuncType = typename core::function_traits<Func>::f_type, // matching std::function
+          class ObservableType = typename core::remove_shared_ptr<       // derive observable-type 
+                                    typename core::extract_type<         // from the first argument
+                                        typename core::function_traits<Func>::arg_types
+                                    , 0>::type
+                                 >::type>
+typename CallbackModule<ObservableType>::Ptr CreateCallbackModule(Func f)
+{
+    FuncType cb = f;
+    return typename CallbackModule<ObservableType>::Ptr(new CallbackModule<ObservableType>(cb));
+}
+
+}
+}
+
+#endif

--- a/include/sempr/processing/CallbackModule.hpp
+++ b/include/sempr/processing/CallbackModule.hpp
@@ -20,12 +20,12 @@ namespace processing {
 template <class ObservableType>
 class CallbackModule : public Module<ObservableType> {
 public:
-    typedef std::function<void(std::shared_ptr<ObservableType>)> callback_t;
-    callback_t callback_;
+    typedef std::function<void(std::shared_ptr<ObservableType>)> observable_cb;
+    observable_cb callback_;
 public:
     using Ptr = std::shared_ptr<CallbackModule>;
 
-    CallbackModule(callback_t callback)
+    CallbackModule(observable_cb callback)
         : callback_(callback)
     {
     }


### PR DESCRIPTION
This PR adds a new ProcessingModule for lazy people like me: The `CallbackModule`. It allows you to easily add callbacks arbitrary event types that are handled in sempr.
Please refrain from using it too excessively, it is meant for small, application specific triggers. In my case, I used it to collect information about changed SpatialObjects to update a visualization later on.

You can use it e.g. with lambdas, like this, but other function- and member-function-pointers should work, too:
```c++
auto myCallbackModule = sempr::processing::CreateCallbackModule(
    [](sempr::core::EntityEvent<sempr::entity::SpatialObject>::Ptr event)
    {
        std::cout << "myCallbackModule reacting to a SpatialObject-Event!" << std::endl;
    }
);

sempr::core::Core core;
core.addModule(myCallbackModule);
```
The `sempr::core::CreateCallbackModule(Func f)` is a helper function that infers the needed template arguments for you, so you **don't** have to write:
```c++
sempr::processing::CallbackModule<sempr::core::EntityEvent<sempr::entity::SpatialObject>>::Ptr
    myCallbackModule(
        new sempr::processing::CallbackModule<sempr::core::EntityEvent<sempr::entity::SpatialObject>>(
            [](sempr::core::EntityEvent<sempr::entity::SpatialObject>::Ptr event)
                {
                    std::cout << "myCallbackModule reacting to SpatialObjectEvent!" << std::endl;
                }
        )
    );
```

I also extended Utility.hpp provide the template magic needed for this simplification:
- `function_traits` extract return type and argument types
- `extract_type` extracts types from the template args of a type,
  e.g. `extract_type<std::Tuple<int, float, double>, 1>::type`
  is `float`.