### PR TITLE
optional param for temporary RDFVector

### DIFF
--- a/include/sempr/entity/RDFEntity.hpp
+++ b/include/sempr/entity/RDFEntity.hpp
@@ -72,7 +72,7 @@ public:
     virtual TripleIteratorWrapper end() const;
 
 protected:
-    RDFEntity(const core::IDGenBase*);
+    RDFEntity(const core::IDGenBase*, bool temporary = false);
 private:
     friend class odb::access;
     RDFEntity();

--- a/include/sempr/entity/RDFVector.hpp
+++ b/include/sempr/entity/RDFVector.hpp
@@ -33,8 +33,8 @@ class RDFVector : public RDFEntity {
     SEMPR_ENTITY
 public:
     using Ptr = std::shared_ptr<RDFVector>;
-    RDFVector();
-    RDFVector(const core::IDGenBase*);
+    RDFVector(bool temporary = false);
+    RDFVector(const core::IDGenBase*, bool temporary = false);
     virtual ~RDFVector(){}
 
     void getTriples(std::vector<Triple>& triples) const;

--- a/src/entity/RDFEntity.cpp
+++ b/src/entity/RDFEntity.cpp
@@ -50,8 +50,8 @@ TripleIterator::~TripleIterator()
 SEMPR_ENTITY_SOURCE(RDFEntity);
 
 
-RDFEntity::RDFEntity(const core::IDGenBase* idgen)
-    : Entity(idgen)
+RDFEntity::RDFEntity(const core::IDGenBase* idgen, bool temporary)
+    : Entity(idgen, temporary)
 {
 }
 

--- a/src/entity/RDFVector.cpp
+++ b/src/entity/RDFVector.cpp
@@ -34,14 +34,14 @@ bool RDFVectorIterator::operator==(const TripleIterator& other) const
 
 SEMPR_ENTITY_SOURCE(RDFVector)
 
-RDFVector::RDFVector(const core::IDGenBase* idgen)
-    : RDFEntity(idgen)
+RDFVector::RDFVector(const core::IDGenBase* idgen, bool temporary)
+    : RDFEntity(idgen, temporary)
 {
     setDiscriminator<RDFVector>();
 }
 
 
-RDFVector::RDFVector() : RDFVector(new core::IDGen<RDFVector>())
+RDFVector::RDFVector(bool temporary) : RDFVector(new core::IDGen<RDFVector>(), temporary)
 {
 }
 


### PR DESCRIPTION
A very small change: Add the `temporary`-parameter to `RDFEntity` and `RDFVector`.

Initially I just wanted to wait for #63 which includes this change (IIRC), but it seems like that PR still needs some time, so... I might as well merge this now. :)