### PR TITLE
SpatialReference inherits SemanticEntity

### DIFF
--- a/include/sempr/entity/SemanticEntity.hpp
+++ b/include/sempr/entity/SemanticEntity.hpp
@@ -51,7 +51,7 @@ namespace traits {
         Specialization for std::strings (which don't work out of the box, but QStrings should)
     */
     template <>
-    struct n3_string<std::string, void>
+    struct n3_string<const std::string, void>
     {
         static std::string from(const std::string& str)
         {
@@ -60,6 +60,9 @@ namespace traits {
             return tmp.toN3().toStdString();
         }
     };
+
+    template <>
+    struct n3_string<std::string, void> : public n3_string<const std::string, void> {};
 
 
     /**
@@ -104,13 +107,16 @@ namespace traits {
         Specialization for strings
     */
     template <>
-    struct plain_string<std::string, void>
+    struct plain_string<const std::string, void>
     {
         static std::string from(const std::string& value)
         {
             return value;
         }
     };
+
+    template <>
+    struct plain_string<std::string, void> : public plain_string<const std::string, void> {};
 
 } /* traits */
 } /* rdf */

--- a/include/sempr/entity/spatial/reference/SpatialReference.hpp
+++ b/include/sempr/entity/spatial/reference/SpatialReference.hpp
@@ -2,7 +2,7 @@
 #define SEMPR_ENTITY_SPATIAL_SPATIALREFERENCE_HPP_
 
 #include <Eigen/Geometry>
-#include <sempr/entity/Entity.hpp>
+#include <sempr/entity/SemanticEntity.hpp>
 
 #include <geos/geom/CoordinateFilter.h>
 #include <geos/geom/CoordinateSequenceFilter.h>
@@ -25,7 +25,7 @@ TODO geometry: methods to assign / change ref systems
        system or a projection reference system.
 */
 #pragma db object
-class SpatialReference : public Entity {
+class SpatialReference : public SemanticEntity {
     SEMPR_ENTITY
 public:
     using Ptr = std::shared_ptr<SpatialReference>;

--- a/src/entity/RuleSet.cpp
+++ b/src/entity/RuleSet.cpp
@@ -11,7 +11,7 @@ RuleSet::RuleSet(const core::IDGenBase* idgen)
     setDiscriminator<RuleSet>();
 
     using namespace sempr::core;
-    prefixes["rdf"] = rdf::baseURI();
+    prefixes["rdf"] = core::rdf::baseURI();
     prefixes["rdfs"] = rdfs::baseURI();
     prefixes["owl"] = owl::baseURI();
     prefixes["sempr"] = sempr::baseURI();

--- a/src/entity/spatial/reference/LocalCS.cpp
+++ b/src/entity/spatial/reference/LocalCS.cpp
@@ -15,6 +15,19 @@ LocalCS::LocalCS(const core::IDGenBase* idgen)
 {
     this->transform_.setIdentity();
     this->setDiscriminator<LocalCS>();
+
+    // export parent to rdf
+    this->registerProperty(
+        "<" + sempr::baseURI() + "hasParent>",
+        parent_
+    );
+
+    // also the type
+    static const std::string type = "<" + sempr::baseURI() + "LocalCS>";
+    this->registerPropertyPlain(
+        core::rdf::type(),
+        type
+    );
 }
 
 

--- a/src/entity/spatial/reference/SpatialReference.cpp
+++ b/src/entity/spatial/reference/SpatialReference.cpp
@@ -11,7 +11,7 @@ SpatialReference::SpatialReference()
 }
 
 SpatialReference::SpatialReference(const core::IDGenBase* idgen)
-    : Entity(idgen)
+    : SemanticEntity(idgen)
 {
 }
 


### PR DESCRIPTION
At some point I needed a semantic description of the spatial reference frames that are present in sempr; knowledge about the parent of a LocalCS, to be precise.

To achieve this I changed SpatialReference to inherit SemanticEntity instead of Entity. That way I could easily register the `parent_` member of LocalCS as a property to be exported as an RDF triple. I also added a property for the (semantic) type of the object (--> "\<sempr:LocalCS\>") using a `static const std::string` variable -- which feels a bit hacky.

- Is inheriting from SemanticEntity okay for SpatialReference?
- Do you have any suggestions for improvements?
- Should we consider to also let other classes inherit from SemanticEntity? E.g., Geometry could export the id of the assigned SpatialReference.